### PR TITLE
Fix #14590

### DIFF
--- a/plugins/htmlwriter/plugin.js
+++ b/plugins/htmlwriter/plugin.js
@@ -215,9 +215,8 @@ CKEDITOR.htmlWriter = CKEDITOR.tools.createClass( {
 			if ( rules && rules.breakAfterClose ) {
 				this.lineBreak();
 				this._.needsSpace = rules.needsSpace;
+				this._.afterCloser = 1;
 			}
-
-			this._.afterCloser = 1;
 		},
 
 		/**


### PR DESCRIPTION
Only output the extra line break if the tag that was closed is breakAfterClose
